### PR TITLE
Time Period Splitting

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -481,11 +481,11 @@
                 html += '<tr>';
                 // AM
                 if (row == amFirstRow && showPeriodLabels) {
-                    html += '<th rowspan="' + amRows.toString() + '" class="periods">' + amPmText[0] + '</th>';
+                    html += '<th rowspan="' + amRows.toString() + '" class="periods" scope="row">' + amPmText[0] + '</th>';
                 }
                 // PM
                 if (row == pmFirstRow && showPeriodLabels) {
-                    html += '<th rowspan="' + pmRows.toString() + '" class="periods">' + amPmText[1] + '</th>';
+                    html += '<th rowspan="' + pmRows.toString() + '" class="periods" scope="row">' + amPmText[1] + '</th>';
                 }
                 for (col = 1; col <= hoursPerRow; col++) {
                     if (showPeriodLabels && row < pmFirstRow && hours[hourCounter] >= 12) {


### PR DESCRIPTION
When the hours range is not 0-23, AM and PM hours have the possibility of showing up in incorrect time period rows. By using the desired number of rows and the number of items associated with each time period, we are able to allocate the appropriate number of rows to each time period and recalculate the number of columns in each row. This allows for situations where AM correctly disappears entirely when no AM hours are included in the range.
