### PR TITLE
jquery 1.9+ compatibility update

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -641,7 +641,8 @@
             html += '</table>';
 
              /* IE6 IFRAME FIX (taken from datepicker 1.5.3, fixed in 0.1.2 */
-            html += ($.browser.msie && parseInt($.browser.version,10) < 7 && !inst.inline ?
+            /* fix for jquery 1.9+ */
+            html += (navigator.userAgent.toString().toLowerCase().indexOf('msie') != -1 && parseInt($.browser.version,10) < 7 && !inst.inline ?
                 '<iframe src="javascript:false;" class="ui-timepicker-cover" frameborder="0"></iframe>' : '');
 
             return html;


### PR DESCRIPTION
$.browser.msie no longer exists in jquery 1.9+. see http://api.jquery.com/jQuery.browser/

There might be more to change or a better way to do this, but this works if you are interested
