### PR TITLE
I've replaced a deprecated call to .browser

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -348,7 +348,7 @@
                 isFixed |= $(this).css('position') == 'fixed';
                 return !isFixed;
             });
-            if (isFixed && $.browser.opera) { // correction for Opera when fixed and scrolled
+            if (isFixed && navigator.userAgent.toString().toLowerCase().indexOf('presto')) { // correction for Opera when fixed and scrolled
                 $.timepicker._pos[0] -= document.documentElement.scrollLeft;
                 $.timepicker._pos[1] -= document.documentElement.scrollTop;
             }


### PR DESCRIPTION
Since this was a check for Opera, and Opera announced they are moving to webkit, I figured it would be more appropriate to fix based on the engine (presto).
