### PR TITLE
Remove this old check for Opera

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -348,10 +348,6 @@
                 isFixed |= $(this).css('position') == 'fixed';
                 return !isFixed;
             });
-            if (isFixed && $.browser.opera) { // correction for Opera when fixed and scrolled
-                $.timepicker._pos[0] -= document.documentElement.scrollLeft;
-                $.timepicker._pos[1] -= document.documentElement.scrollTop;
-            }
 
             var offset = { left: $.timepicker._pos[0], top: $.timepicker._pos[1] };
 


### PR DESCRIPTION
This Opera workaround originally came from jqueryUI's datepicker. It's since been removed:
https://github.com/jquery/jquery-ui/commit/30c064427bc697bce992c68ce2db7ddd529c76e9

I've created a fiddle that shows the timepicker within a fixed element which still works in Opera 12 regardless of the override being in place: http://jsfiddle.net/mzkc4/5/
My guess is the Opera devs wrote in a workaround for the workaround...

Timepicker should remove this check, too. With jQuery 1.9, having the $.browser call causes a runtime error.
