### PR TITLE
Fixed issues with TurboLinks and automatically add a button if not set in options

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -277,6 +277,13 @@
             }
             if (showOn == 'button' || showOn == 'both') { // pop-up time picker when 'button' element is clicked
                 var button = this._get(inst, 'button');
+
+                // Add button if button element is not set
+                if(button == null) {
+                    button = $('<button class="ui-timepicker-trigger" type="button">...</button>');
+                    input.after(button);
+                }
+
                 $(button).bind("click.timepicker", function () {
                     if ($.timepicker._timepickerShowing && $.timepicker._lastInput == input[0]) {
                         $.timepicker._hideTimepicker();


### PR DESCRIPTION
Fixed issues with timepicker when using Rails TurboLinks applications (similar to https://github.com/jquery/jquery-ui/commit/f20486d1231fce4a559bc70f0595a071e9efc59b).
Automatically add a button if showOn is 'both' or 'button' and button is not explicitely set (similar to jquery ui datepicker).
