### PR TITLE
Fix bug where if maxTime or minTime was 0 it wouldn't call update to minute display when changing hours.

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -1279,7 +1279,7 @@
             var onMinuteShow = this._get(inst, 'onMinuteShow'),
                 maxTime = this._get(inst, 'maxTime'),
                 minTime = this._get(inst, 'minTime');
-            if (onMinuteShow || maxTime.minute || minTime.minute) {
+            if (onMinuteShow || !isNaN(parseInt(maxTime.minute)) || !isNaN(parseInt(minTime.minute))) {
                 // this will trigger a callback on selected hour to make sure selected minute is allowed. 
                 this._updateMinuteDisplay(inst);
             }


### PR DESCRIPTION
Just noticed while testing some functionality.  Quick fix.
