### PR TITLE
Added support for entering time without separator.

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -84,6 +84,7 @@
             onClose: null,                  // Define a callback function when the timepicker is closed
 
             timeSeparator: ':',             // The character to use to separate hours and minutes.
+            timeWithoutSeparator: true,     // Accept time input without seperator.
             periodSeparator: ' ',           // The character to use to separate the time from the time period.
             showPeriod: false,              // Define whether or not to show AM/PM with selected time
             showPeriodLabels: true,         // Show the AM/PM labels on the left of the time picker
@@ -1200,6 +1201,7 @@
                 return '';
 
             var timeSeparator = this._get(inst, 'timeSeparator'),
+                timeWithoutSeparator = this._get(inst,'timeWithoutSeparator'),
                 amPmText = this._get(inst, 'amPmText'),
                 showHours = this._get(inst, 'showHours'),
                 showMinutes = this._get(inst, 'showMinutes'),
@@ -1219,6 +1221,11 @@
             // check for minutes only
             else if ( ( ! showHours) && (showMinutes) ) {
                 retVal.minutes = parseInt(timeVal, 10);
+            }
+            // check if time seperator requirement is waived and at least 4 characters were entered
+            else if ( (timeWithoutSeparator) && (timeVal.length >= 4) ){
+                retVal.hours = parseInt(timeVal.substr(0, 2), 10);
+                retVal.minutes = parseInt(timeVal.substr(2, 3), 10);
             }
 
             if (showHours) {


### PR DESCRIPTION
Hi there

I've changed the behaviour of timeParse a little. Now if it doesn't find a separator and the timeVal string contains at least 4 characters (and the timepicker is not configured for minutes or hours only) it simply uses the first 2 characters for the hours and the second 2 for the minutes. Also added a configuration option that can turn this behaviour off.

The main reason I did this is because I've come to expect this kind of behaviour (a time entering field interpreting, for example, "1345" as "13:45").

Cheers,

Wieke
