### PR TITLE
parseTime Should Always Return retVal

### DIFF
--- a/jquery.ui.timepicker.js
+++ b/jquery.ui.timepicker.js
@@ -1196,8 +1196,8 @@
             retVal.hours = -1;
             retVal.minutes = -1;
 
-            if(!timeVal)
-                return '';
+            if (!timeVal)
+                return retVal;
 
             var timeSeparator = this._get(inst, 'timeSeparator'),
                 amPmText = this._get(inst, 'amPmText'),


### PR DESCRIPTION
Previously parseTime was returning '' when timeVal was null, but it should always return retVal instead.